### PR TITLE
Update for SMAPI 3.0

### DIFF
--- a/PumpkinKing/PumpkinKing.csproj
+++ b/PumpkinKing/PumpkinKing.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\BigSteam\steamapps\common\Stardew Valley\0Harmony.dll</HintPath>
+      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/PumpkinKing/PumpkinKing.csproj
+++ b/PumpkinKing/PumpkinKing.csproj
@@ -12,8 +12,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>..\..\..\..\..\..\BigSteam\steamapps\common\Stardew Valley\0Harmony.dll</HintPath>
     </Reference>
@@ -51,17 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/PumpkinKing/manifest.json
+++ b/PumpkinKing/manifest.json
@@ -1,15 +1,13 @@
 ﻿{
-   "Name": "PumpkinKing",
-   "Author": "KirbyLink",
-   "Version": "1.1.0",
-   "Description": "Adds a new scarecrow which effects nearby pumpkins!",
-   "UniqueID": "kirbylink.pumpkinking",
-   "EntryDll": "pumpkinking.dll",
-   "MinimumApiVersion": "2.0",
-   "UpdateKeys": ["Nexus:3006"],
-   "Dependencies": [
-    {
-      "UniqueID": "Platonymous.CustomFarming"
-    }
+  "Name": "The Pumpkin King",
+  "Author": "KirbyLink",
+  "Version": "1.1.0",
+  "Description": "Adds a new scarecrow which effects nearby pumpkins!",
+  "UniqueID": "kirbylink.pumpkinking",
+  "EntryDll": "PumpkinKing.dll",
+  "MinimumApiVersion": "2.10.2",
+  "UpdateKeys": [ "Nexus:3006" ],
+  "Dependencies": [
+    { "UniqueID": "Platonymous.CustomFarming" }
   ]
 }

--- a/PumpkinKing/packages.config
+++ b/PumpkinKing/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the code for SMAPI 2.10.2 + 3.0 (in particular, `EntryDll` is case-sensitive in SMAPI 3.0).
* Fixes compatibility with Linux/Mac (per the above).
* Updates the mod build package and migrates to the new package format.

Let me know if you want me to change anything!